### PR TITLE
Fix color constrast for blockquotes

### DIFF
--- a/.vuepress/theme/styles/index.styl
+++ b/.vuepress/theme/styles/index.styl
@@ -52,3 +52,9 @@ h6 {
   src: url("/fonts/Evolventa/Evolventa-Bold.ttf");
   font-weight: 800;
 }
+
+/** content **/
+
+blockquote {
+  color: #666;
+}


### PR DESCRIPTION
Background is white, color was #999 (very light gray) leading to a color contrast issue.


![Screenshot+2019-10-08+at+10 35 15](https://user-images.githubusercontent.com/295709/66380271-5ff9bc80-e9b7-11e9-9e00-af6d5a9aaf27.png)