### PR TITLE
Accueil : sidebar custom par groupes

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -1,11 +1,45 @@
 const {getSidebar} = require('vuepress-theme-gouv-fr/sidebar.js')
 
+function sidebar () {
+  data = getSidebar()
+
+  data['/'] = [
+    {
+      title: 'Ouverture et circulation des données',
+      collapsable: false,
+      children: [
+        ['/qualite/', "Comment préparer des données à l'ouverture / la circulation ?"],
+        ['/juridique/', "Quels jeux de données doivent être publiés en open data ?"],
+        ['/data.gouv.fr/', "Comment publier des jeux de données sur data.gouv.fr ?"],
+      ]
+    },
+    {
+      title: 'Algorithmes publics',
+      collapsable: false,
+      children: [
+        ['/algorithmes/', "Les algorithmes publics : pourquoi et comment les expliquer ?"],
+      ]
+    },
+    {
+      title: 'Codes sources',
+      collapsable: false,
+      children: [
+        ['/logiciels/', "Codes sources du secteur public : lesquels ouvrir, pourquoi et comment ?"],
+      ]
+    },
+  ]
+
+  return data
+}
+
+sidebar();
+
 module.exports = {
   title: 'guides.etalab.gouv.fr',
   description: "Les guides d'Etalab : vous accompagner dans la réalisation de vos projets relatifs aux données, algorithmes et codes sources.",
   theme: 'vuepress-theme-gouv-fr',
   themeConfig: {
-    sidebar: getSidebar(),
+    sidebar: sidebar(),
     sidebarDepth: 1,
     logo: '/images/logo-marianne.svg',
     // lastUpdated: 'Dernière mise à jour',

--- a/accueil.md
+++ b/accueil.md
@@ -1,6 +1,3 @@
----
-sidebar: false
----
 # Les guides d'Etalab 
 
 Dans le cadre de vos missions, vous pouvez être amenés à produire, collecter ou utiliser des données, codes sources de logiciel ou algorithmes. Ces derniers représentent des sources de valeur pour votre organisation, mais également pour d'autres structures. La montée en qualité, la documentation, l'ouverture et la circulation de ces ressources ont vocation à améliorer la qualité de vos activités et à favoriser la création de nouveaux services innovants.


### PR DESCRIPTION
Mathilde souhaitait retrouver les groupes de guide sur le sommaire. Cette PR fait ceci, au prix de devoir gérer à la main ces groupes.

![image](https://user-images.githubusercontent.com/295709/71097914-1d234480-21b1-11ea-8b1e-1aedb3629617.png)
